### PR TITLE
Setup protocols for QuoteViewController

### DIFF
--- a/QuoteGenerator-MVVM-Combine.xcodeproj/project.pbxproj
+++ b/QuoteGenerator-MVVM-Combine.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		E272C03129D6A69A0083AFF4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E272C02F29D6A69A0083AFF4 /* LaunchScreen.storyboard */; };
 		E272C03D29D6A7BF0083AFF4 /* QuoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E272C03B29D6A7BF0083AFF4 /* QuoteView.swift */; };
 		E272C03E29D6A7BF0083AFF4 /* QuoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E272C03C29D6A7BF0083AFF4 /* QuoteViewController.swift */; };
+		E272C04129D894930083AFF4 /* ViewConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E272C04029D894930083AFF4 /* ViewConfigurable.swift */; };
+		E272C04329D895B00083AFF4 /* ViewModelBindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E272C04229D895B00083AFF4 /* ViewModelBindable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +26,8 @@
 		E272C03229D6A69A0083AFF4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E272C03B29D6A7BF0083AFF4 /* QuoteView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuoteView.swift; sourceTree = "<group>"; };
 		E272C03C29D6A7BF0083AFF4 /* QuoteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuoteViewController.swift; sourceTree = "<group>"; };
+		E272C04029D894930083AFF4 /* ViewConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewConfigurable.swift; sourceTree = "<group>"; };
+		E272C04229D895B00083AFF4 /* ViewModelBindable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelBindable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,8 +75,18 @@
 			children = (
 				E272C03B29D6A7BF0083AFF4 /* QuoteView.swift */,
 				E272C03C29D6A7BF0083AFF4 /* QuoteViewController.swift */,
+				E272C03F29D894720083AFF4 /* Protocols */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		E272C03F29D894720083AFF4 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				E272C04029D894930083AFF4 /* ViewConfigurable.swift */,
+				E272C04229D895B00083AFF4 /* ViewModelBindable.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -148,6 +162,8 @@
 				E272C02929D6A6980083AFF4 /* ViewController.swift in Sources */,
 				E272C02529D6A6980083AFF4 /* AppDelegate.swift in Sources */,
 				E272C03D29D6A7BF0083AFF4 /* QuoteView.swift in Sources */,
+				E272C04329D895B00083AFF4 /* ViewModelBindable.swift in Sources */,
+				E272C04129D894930083AFF4 /* ViewConfigurable.swift in Sources */,
 				E272C03E29D6A7BF0083AFF4 /* QuoteViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/QuoteGenerator-MVVM-Combine/View/Protocols/ViewConfigurable.swift
+++ b/QuoteGenerator-MVVM-Combine/View/Protocols/ViewConfigurable.swift
@@ -1,0 +1,36 @@
+//
+//  ViewConfigurable.swift
+//  QuoteGenerator-MVVM-Combine
+//
+//  Created by Ignacio Cervino on 01/04/2023.
+//
+
+import Foundation
+
+/// A protocol defined for UIViewControllers and UIViews that use UI programatically
+protocol ViewConfigurable {
+    /// Use this function to add all your custom subviews
+    func buildViewHierarchy()
+    
+    func setupConstraints()
+    
+    /// Use this function to setup the actionable targets of each subview if needed
+    func setupTargets()
+    
+    /// Use this function to setup the button tap publishers of each subview if needed
+    func observeButtonTaps()
+}
+
+/// Default implementation
+extension ViewConfigurable {
+    func configureView() {
+        buildViewHierarchy()
+        setupConstraints()
+        setupTargets()
+        observeButtonTaps()
+    }
+    func buildViewHierarchy() {}
+    func setupConstraints() {}
+    func setupTargets() {}
+    func observeButtonTaps() {}
+}

--- a/QuoteGenerator-MVVM-Combine/View/Protocols/ViewModelBindable.swift
+++ b/QuoteGenerator-MVVM-Combine/View/Protocols/ViewModelBindable.swift
@@ -1,0 +1,22 @@
+//
+//  ViewModelBindable.swift
+//  QuoteGenerator-MVVM-Combine
+//
+//  Created by Ignacio Cervino on 01/04/2023.
+//
+
+import Foundation
+
+/// Protocol defined to be used by UIViewControllers and UIViews that need to be bindable to a view model and vice-versa.
+protocol ViewModelBindable {
+    /// Use this function when your view properties needs to be binded to a viewModel property
+    func bindViewToViewModel()
+    /// Use this function when you need to bind a property from your view model to your view
+    func bindViewModelToView()
+}
+
+// Default implementations so each can be optional
+extension ViewModelBindable {
+    func bindViewToViewModel() {}
+    func bindViewModelToView() {}
+}

--- a/QuoteGenerator-MVVM-Combine/View/QuoteView.swift
+++ b/QuoteGenerator-MVVM-Combine/View/QuoteView.swift
@@ -18,7 +18,7 @@ class QuoteView: UIView {
         return VStackView
     }()
     
-    private lazy var quoteLbl: UILabel = {
+    private(set) lazy var quoteLbl: UILabel = {
         let lbl = UILabel()
         lbl.font = .systemFont(ofSize: 24)
         lbl.textAlignment = .center
@@ -27,7 +27,7 @@ class QuoteView: UIView {
         return lbl
     }()
     
-    private lazy var refreshBtn: UIButton = {
+    private(set) lazy var refreshBtn: UIButton = {
         let button = UIButton(type: .system)
         button.backgroundColor = .blue
         button.setTitle("Refresh", for: .normal)

--- a/QuoteGenerator-MVVM-Combine/View/QuoteViewController.swift
+++ b/QuoteGenerator-MVVM-Combine/View/QuoteViewController.swift
@@ -20,14 +20,25 @@ final class QuoteViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func loadView() {
+        view = quoteView
         view.backgroundColor = .white
-        buildViewHierarchy()
     }
     
-    private func buildViewHierarchy() {
-        view.addSubview(quoteView)
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupConstraints()
+        setupTargets()
+    }
+}
+
+extension QuoteViewController: ViewModelBindable {
+    
+}
+
+extension QuoteViewController: ViewConfigurable {
+    
+    func setupConstraints() {
         quoteView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             quoteView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -35,6 +46,17 @@ final class QuoteViewController: UIViewController {
             quoteView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             quoteView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+    }
+    
+    func setupTargets() {
+        quoteView.refreshBtn.addTarget(self, action: #selector(refreshClick), for: .touchUpInside)
+    }
+}
+
+// MARK: - Targets
+private extension QuoteViewController {
+    @objc func refreshClick() {
+        //viewModel.refreshClick()
     }
 }
 


### PR DESCRIPTION
## Changelog
This PR adds two protocols **ViewConfigurable** and **ViewModelBindable**.
**ViewConfigurable** is a protocol that allows views to be configured in a consistent way. It defines a set of methods that a view can implement to allow for customizable behavior.
Overall, ViewConfigurable is a way to promote consistency and ease-of-use in view configuration across different parts of an iOS app.

By implementing the **ViewModelBindable** interface, a View component can indicate that it is capable of binding to a ViewModel, and the framework can use this interface to automatically establish the binding between the two components. This helps to simplify the development of MVVM-based applications and makes it easier to maintain a clean separation of concerns between the different components of the architecture.


